### PR TITLE
Make viz dependencies optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ dependencies = [
   "morph-tool",
   "jsonschema",
   "luigi",
-  "pydot",
-  "matplotlib",
   "brainbuilder>=0.20.1",
 ]
 classifiers = [
@@ -45,7 +43,12 @@ classifiers = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
+viz = [
+  "pydot",
+  "matplotlib",
+]
 docs = [
+  "blue-cwl[viz]",
   "sphinx-bluebrain-theme",
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,7 @@ envlist =
 
 [testenv]
 deps = {[base]testdeps}
+extras = viz
 commands_pre = /bin/mkdir -p {[base]basetemp}
 commands = python -m pytest --basetemp=tmptestdir/{envname} tests/unit {posargs}
 allowlist_externals =
@@ -115,6 +116,7 @@ deps =
     {[base]testdeps}
     coverage[toml]
     pytest-cov
+extras = viz
 commands =
     python -m pytest --cov={[base]name} --basetemp=tmptestdir/{envname} tests/unit {posargs}
     coverage xml


### PR DESCRIPTION
Create optional dependency `blue-cwl[viz]` to include visualization dependencies.