### PR TITLE
Bring File closer to CWL specification

### DIFF
--- a/src/blue_cwl/core/cwl_types.py
+++ b/src/blue_cwl/core/cwl_types.py
@@ -92,7 +92,7 @@ class File(_Path):
 
     @property
     def contents(self):
-        """Return contents of file."""
+        """Return first 64KB from file."""
         return Path(self.path).open(buffering=FILE_BUFFER_SIZE, encoding="utf-8").read()
 
     @property
@@ -105,7 +105,7 @@ class File(_Path):
         """Return the sha1 checksum of the file."""
         with open(self.path, "rb") as f:
             sha1 = hashlib.sha1()  # noqa: S324
-            while chunk := f.read(65536):
+            while chunk := f.read(FILE_BUFFER_SIZE):
                 sha1.update(chunk)
         return sha1.hexdigest()
 

--- a/tests/unit/core/test_cwl_types.py
+++ b/tests/unit/core/test_cwl_types.py
@@ -2,27 +2,67 @@ import os
 import pytest
 from blue_cwl.core.exceptions import CWLError
 from blue_cwl.core import cwl_types as tested
+from blue_cwl.utils import cwd
 
 
-def test_File():
-    res = tested.File(path="/gpfs/foo.txt")
-    assert res.path == "/gpfs/foo.txt"
+def test_File(tmp_path):
+    """
+    File fields: https://www.commonwl.org/v1.0/CommandLineTool.html#File
+    """
+
+    contents = "foo"
+
+    path = tmp_path / "foo.txt"
+    path.write_text(contents)
+
+    parent_dir = str(tmp_path)
+    path = str(path)
+    uri = f"file://{path}"
+    size = 3
+    checksum = "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33"
+
+    res = tested.File(path=path)
+    assert res.path == path
     assert res.basename == "foo.txt"
+    assert res.dirname == parent_dir
+    assert res.nameroot == "foo"
+    assert res.nameext == ".txt"
     assert os.path.isabs(res.location[7:])
-    assert res.location == "file:///gpfs/foo.txt"
+    assert res.location == uri
+    assert res.size == size
+    assert res.contents == contents
+    assert res.checksum == checksum
 
-    res = tested.File(path="foo.txt")
-    assert res.path == "foo.txt"
+    with cwd(tmp_path):
+        res = tested.File(path="foo.txt")
+        assert res.path == "foo.txt"
+        assert res.basename == "foo.txt"
+        assert res.dirname == "."
+        assert res.nameroot == "foo"
+        assert res.nameext == ".txt"
+        assert os.path.isabs(res.location[7:])
+        assert res.location == uri
+        assert res.size == size
+        assert res.contents == contents
+        assert res.checksum == checksum
+
+    res = tested.File(location=uri)
+    assert res.path == path
+    assert res.basename == "foo.txt"
+    assert res.dirname == parent_dir
+    assert res.nameroot == "foo"
+    assert res.nameext == ".txt"
     assert os.path.isabs(res.location[7:])
-    assert res.location.endswith("foo.txt")
-    assert res.basename == "foo.txt"
-
-    res = tested.File(location="file:///gpfs/foo.txt")
-    assert res.path == "/gpfs/foo.txt"
-    assert res.basename == "foo.txt"
+    assert res.location == uri
+    assert res.size == size
+    assert res.contents == contents
+    assert res.checksum == checksum
 
 
 def test_Directory():
+    """
+    Directory fields: https://www.commonwl.org/v1.0/CommandLineTool.html#Directory
+    """
     res = tested.Directory(path="/gpfs/foo")
     assert res.path == "/gpfs/foo"
     assert res.basename == "foo"


### PR DESCRIPTION
Add all expected fields in the File object required by expressions.
This is a step towards enabling expressions that load the file contents during runtime.